### PR TITLE
⚡ Bolt: Offload Biot-Savart particle calculation to GPU

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,9 @@
+# Bolt's Journal
+
+## 2024-05-22 - [Initial Setup]
+**Learning:** Starting fresh. No critical learnings yet.
+**Action:** Keep eyes open for performance patterns.
+
+## 2024-05-22 - [Vortex Wake Bottleneck]
+**Learning:** The Free Vortex Wake (FVW) module in AeroDyn contains explicit N-body calculations ($O(N^2)$) in `WakeInducedVelocities`. This is a classic candidate for GPU acceleration. The code uses `ui_seg` (segments) or `ui_part_nograd` (particles) for these calculations.
+**Action:** Target `FVW_BiotSavart.f90` for OpenMP offloading optimization. Start with `ui_part_nograd` as it is cleaner and simpler.

--- a/modules/aerodyn/src/FVW_BiotSavart.f90
+++ b/modules/aerodyn/src/FVW_BiotSavart.f90
@@ -350,7 +350,7 @@ subroutine ui_part_nograd(nCPS, CPs, nPart, Part, Alpha, RegFunction, RegParam, 
    real(ReKi), dimension(3) :: DP      !< 
    integer :: icp,ip
    ! TODO: inlining of regularization
-   !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO MAP(TO: CPs(1:3,1:nCPs), Part(1:3,1:nPart), Alpha(1:3,1:nPart), RegParam(1:nPart)) &
+   !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO MAP(TO: CPs(1:3,1:nCPs), Part(1:3,1:nPart), Alpha(1:3,1:nPart), RegParam(1:nPart), RegFunction) &
    !$OMP MAP(TOFROM: UIout(1:3,1:nCPs)) PRIVATE(icp,ip, DP, UItmp)
    do icp=1,nCPs ! loop on CPs 
       do ip=1,nPart ! loop on particles

--- a/modules/aerodyn/src/FVW_BiotSavart.f90
+++ b/modules/aerodyn/src/FVW_BiotSavart.f90
@@ -350,8 +350,8 @@ subroutine ui_part_nograd(nCPS, CPs, nPart, Part, Alpha, RegFunction, RegParam, 
    real(ReKi), dimension(3) :: DP      !< 
    integer :: icp,ip
    ! TODO: inlining of regularization
-   !$OMP PARALLEL DEFAULT(SHARED)
-   !$OMP DO PRIVATE(icp,ip, DP, UItmp) schedule(runtime)
+   !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO MAP(TO: CPs(1:3,1:nCPs), Part(1:3,1:nPart), Alpha(1:3,1:nPart), RegParam(1:nPart)) &
+   !$OMP MAP(TOFROM: UIout(1:3,1:nCPs)) PRIVATE(icp,ip, DP, UItmp)
    do icp=1,nCPs ! loop on CPs 
       do ip=1,nPart ! loop on particles
          UItmp(1:3) = 0.0_ReKi
@@ -360,12 +360,12 @@ subroutine ui_part_nograd(nCPS, CPs, nPart, Part, Alpha, RegFunction, RegParam, 
          UIout(1:3,icp)=UIout(1:3,icp)+UItmp(1:3)
       enddo! loop on particles
    enddo ! loop CPs
-   !$OMP END DO 
-   !$OMP END PARALLEL
+   !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
 end subroutine ui_part_nograd
 
 !> Induced velocity from 1 particle at 1 control point. The velocity gradient is not computed
 subroutine ui_part_nograd_11(DeltaP, Alpha, RegFunction, RegParam, Ui)
+   !$omp declare target
    real(ReKi), dimension(3), intent(out) :: Ui          !< no side effects
    real(ReKi), dimension(3), intent(in)  :: DeltaP      !< CP-PP "control point - particle point"
    real(ReKi), dimension(3), intent(in)  :: Alpha       !< Particle intensity [m^2/s] alpha=om.dV

--- a/modules/aerodyn/src/FVW_BiotSavart.f90
+++ b/modules/aerodyn/src/FVW_BiotSavart.f90
@@ -369,8 +369,8 @@ subroutine ui_part_nograd_11(DeltaP, Alpha, RegFunction, RegParam, Ui)
    real(ReKi), dimension(3), intent(out) :: Ui          !< no side effects
    real(ReKi), dimension(3), intent(in)  :: DeltaP      !< CP-PP "control point - particle point"
    real(ReKi), dimension(3), intent(in)  :: Alpha       !< Particle intensity [m^2/s] alpha=om.dV
-   integer(IntKi),           intent(in)  :: RegFunction !< 
-   real(ReKi),               intent(in)  :: RegParam    !< 
+   integer(IntKi), value,    intent(in)  :: RegFunction !<
+   real(ReKi),     value,    intent(in)  :: RegParam    !<
    real(ReKi),dimension(3) :: C          !< Cross product of Alpha and r
    real(ReKi)              :: E          !< Exponential poart for the mollifider
    real(ReKi)              :: r3_inv     !< 


### PR DESCRIPTION
💡 What: Introduced OpenMP target offloading for the N-body particle interaction calculation in FVW_BiotSavart.f90.
🎯 Why: The N-body calculation is O(N^2) and is a significant bottleneck in Free Vortex Wake simulations. Offloading to GPU can provide massive speedups.
📊 Impact: Enables GPU acceleration for the 'particle' velocity method in AeroDyn. Falls back to CPU if no GPU/offload support is available.
🔬 Measurement: Verify correctness with 'ctest' (when environment supports it). Benchmark with large N (number of particles) to see speedup.

---
*PR created automatically by Jules for task [7370845661428986272](https://jules.google.com/task/7370845661428986272) started by @mayankchetan*