### PR TITLE
⚡ Bolt: Offload Biot-Savart N-Body to GPU

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-01-31 - OpenMP Offloading in Fortran N-Body
+**Learning:** When offloading Fortran subroutines that call other internal subroutines, scalar arguments must be passed by `VALUE` to avoid issues on the device. Module parameters used on the device must be explicitly declared with `!$OMP DECLARE TARGET`.
+**Action:** Always check argument attributes and module scope visibility when porting legacy Fortran to GPU.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-01-31 - OpenMP Offloading in Fortran N-Body
 **Learning:** When offloading Fortran subroutines that call other internal subroutines, scalar arguments must be passed by `VALUE` to avoid issues on the device. Module parameters used on the device must be explicitly declared with `!$OMP DECLARE TARGET`.
 **Action:** Always check argument attributes and module scope visibility when porting legacy Fortran to GPU.
+## 2026-01-31 - Fortran OpenMP Syntax Strictness
+**Learning:** The closing directive for combined OpenMP constructs like `! TARGET TEAMS DISTRIBUTE PARALLEL DO` must be strictly matched, e.g., `! END TARGET TEAMS DISTRIBUTE PARALLEL DO`. Simply using `! END TEAMS...` is insufficient and causes compilation errors in some compilers (e.g. gfortran).
+**Action:** Always verify the full string match for OpenMP END directives.

--- a/modules/aerodyn/src/FVW_BiotSavart.f90
+++ b/modules/aerodyn/src/FVW_BiotSavart.f90
@@ -366,7 +366,7 @@ subroutine ui_part_nograd(nCPS, CPs, nPart, Part, Alpha, RegFunction, RegParam, 
          UIout(1:3,icp)=UIout(1:3,icp)+UItmp(1:3)
       enddo! loop on particles
    enddo ! loop CPs
-   !$OMP END TEAMS DISTRIBUTE PARALLEL DO
+   !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
 end subroutine ui_part_nograd
 
 !> Induced velocity from 1 particle at 1 control point. The velocity gradient is not computed

--- a/modules/aerodyn/src/FVW_BiotSavart.f90
+++ b/modules/aerodyn/src/FVW_BiotSavart.f90
@@ -27,6 +27,10 @@ module FVW_BiotSavart
    real(ReKi),parameter    :: fourpi_inv =  0.25_ReKi / ACOS(-1.0_Reki )
    real(ReKi),parameter    :: fourpi     =  4.00_ReKi * ACOS(-1.0_Reki )
 
+   !$OMP DECLARE TARGET(PRECISION_UI, PRECISION_EPS, MIN_EXP_VALUE, MINDENOM, MINNORM)
+   !$OMP DECLARE TARGET(idRegNone, idRegRankine, idRegLambOseen, idRegVatistas, idRegOffset, idRegExp, idRegCompact)
+   !$OMP DECLARE TARGET(fourpi_inv, fourpi)
+
 contains
 
 
@@ -350,8 +354,10 @@ subroutine ui_part_nograd(nCPS, CPs, nPart, Part, Alpha, RegFunction, RegParam, 
    real(ReKi), dimension(3) :: DP      !< 
    integer :: icp,ip
    ! TODO: inlining of regularization
-   !$OMP PARALLEL DEFAULT(SHARED)
-   !$OMP DO PRIVATE(icp,ip, DP, UItmp) schedule(runtime)
+   !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO &
+   !$OMP MAP(TO: CPs(:,1:nCPs), Part(:,1:nPart), Alpha(:,1:nPart), RegParam(1:nPart), nCPs, nPart, RegFunction) &
+   !$OMP MAP(TOFROM: UIout(:,1:nCPs)) &
+   !$OMP PRIVATE(icp,ip, DP, UItmp)
    do icp=1,nCPs ! loop on CPs 
       do ip=1,nPart ! loop on particles
          UItmp(1:3) = 0.0_ReKi
@@ -360,17 +366,17 @@ subroutine ui_part_nograd(nCPS, CPs, nPart, Part, Alpha, RegFunction, RegParam, 
          UIout(1:3,icp)=UIout(1:3,icp)+UItmp(1:3)
       enddo! loop on particles
    enddo ! loop CPs
-   !$OMP END DO 
-   !$OMP END PARALLEL
+   !$OMP END TEAMS DISTRIBUTE PARALLEL DO
 end subroutine ui_part_nograd
 
 !> Induced velocity from 1 particle at 1 control point. The velocity gradient is not computed
 subroutine ui_part_nograd_11(DeltaP, Alpha, RegFunction, RegParam, Ui)
+   !$OMP DECLARE TARGET
    real(ReKi), dimension(3), intent(out) :: Ui          !< no side effects
    real(ReKi), dimension(3), intent(in)  :: DeltaP      !< CP-PP "control point - particle point"
    real(ReKi), dimension(3), intent(in)  :: Alpha       !< Particle intensity [m^2/s] alpha=om.dV
-   integer(IntKi),           intent(in)  :: RegFunction !< 
-   real(ReKi),               intent(in)  :: RegParam    !< 
+   integer(IntKi),           intent(in), VALUE  :: RegFunction !<
+   real(ReKi),               intent(in), VALUE  :: RegParam    !<
    real(ReKi),dimension(3) :: C          !< Cross product of Alpha and r
    real(ReKi)              :: E          !< Exponential poart for the mollifider
    real(ReKi)              :: r3_inv     !< 


### PR DESCRIPTION
* 💡 What: Implemented OpenMP offloading for the `ui_part_nograd` subroutine in `FVW_BiotSavart.f90`.
* 🎯 Why: This subroutine performs an $O(N^2)$ N-body calculation for induced velocities, which is a major bottleneck in wake simulations. Offloading to GPU significantly accelerates this.
* 📊 Impact: Enables GPU acceleration for the Free Vortex Wake module. Performance gain depends on problem size ($N$) and hardware.
* 🔬 Measurement: Verify correctness by running regression tests (on CI). Compare execution time of `FVW_UpdateStates` with and without GPU offloading on a suitable test case.

---
*PR created automatically by Jules for task [4486989324144807147](https://jules.google.com/task/4486989324144807147) started by @mayankchetan*