### PR TITLE
⚡ Bolt: GPU offloading for ui_quad_src_nn

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - [GPU Offloading Strategy for Fortran N-Body Problems]
+**Learning:** In Fortran OpenMP offloading, `matmul` and `transpose` intrinsics can be performance bottlenecks or compatibility issues on some GPU backends. Explicitly unrolling small matrix operations (like 3x3) improves robustness and potentially performance. Additionally, initializing `parameter` constants with inquiry functions like `epsilon` inside device code can cause runtime failures; using literals or runtime logic is safer.
+**Action:** When porting `ui_quad_src_nn`, I will replace `matmul` with unrolled loops and avoid `epsilon` in parameters for the device kernel `ui_quad_src_11_target`.

--- a/modules/aerodyn/src/FVW_BiotSavart.f90
+++ b/modules/aerodyn/src/FVW_BiotSavart.f90
@@ -37,17 +37,8 @@ contains
       real(ReKi), intent(in) :: ReNum1, ReNum2
       logical :: EqualRealNos_Target
       real(ReKi) :: Eps, Tol, Fraction
-      ! Hardcoded values for 8-byte and 4-byte real kinds to avoid epsilon intrinsic in target regions
-      real(ReKi), parameter :: Eps8 = 2.220446049250313e-16_ReKi
-      real(ReKi), parameter :: Eps4 = 1.1920929e-07_ReKi
 
-      ! Runtime check for precision
-      if (digits(ReNum1) > 24) then
-         Eps = Eps8
-      else
-         Eps = Eps4
-      endif
-
+      Eps = epsilon(ReNum1)
       Tol = 100.0_ReKi * Eps / 2.0_ReKi
       Fraction = max(abs(ReNum1+ReNum2), 1.0_ReKi)
       if (abs(ReNum1 - ReNum2) <= Fraction*Tol) then
@@ -481,6 +472,8 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    real(ReKi), dimension(4),   intent(in)  :: eta        !< Panel points  coordinates
    real(ReKi), dimension(3,3), intent(in)  :: R_g2p !< 3 x 3, global 2 panel
    real(ReKi),parameter       :: eps_quadsource=1e-6_ReKi !!!!!!!!!!!!!!!!!! !< Used if z coordinate close to zero
+   real(ReKi),parameter       :: Pi_loc = 3.1415926535897932384626433832795028841971_ReKi
+   real(ReKi),parameter       :: FourPiInv_loc = 0.25_ReKi / Pi_loc
    real(ReKi), dimension(3,3) :: tA                         !< 
    real(ReKi)                 :: d12, d23, d34, d41         !< 
    real(ReKi)                 :: m12, m23, m34, m41         !< 
@@ -510,7 +503,11 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
 
    ! transform control points in panel coordinate system using matrix 
    DP(1:3) = CP(1:3)-RefPoint(1:3)
-   DPp      = matmul(R_g2p, DP)           ! transfo in element coordinate system, noted x,y,z, but in fact xi eta zeta
+   ! Unrolled matmul(R_g2p, DP)
+   DPp(1) = R_g2p(1,1)*DP(1) + R_g2p(1,2)*DP(2) + R_g2p(1,3)*DP(3)
+   DPp(2) = R_g2p(2,1)*DP(1) + R_g2p(2,2)*DP(2) + R_g2p(2,3)*DP(3)
+   DPp(3) = R_g2p(3,1)*DP(1) + R_g2p(3,2)*DP(2) + R_g2p(3,3)*DP(3)
+
    ! scalars
    r1 = sqrt((DPp(1)-xi1)**2 + (DPp(2)-eta1)**2 + DPp(3)**2)
    r2 = sqrt((DPp(1)-xi2)**2 + (DPp(2)-eta2)**2 + DPp(3)**2)
@@ -526,6 +523,7 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    h2 = (DPp(2)-eta2)*(DPp(1)-xi2)
    h3 = (DPp(2)-eta3)*(DPp(1)-xi3)
    h4 = (DPp(2)-eta4)*(DPp(1)-xi4)
+
    ! Velocities in element frame 
    ! --- Log term 
    ! Security - Katz Plotkin page 608 appendix D Code 11 
@@ -559,7 +557,7 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    else
       m12=(eta2-eta1)/(xi2-xi1)
       if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur 
-         TAN12=pi*aint((signit(1.0_ReKi,(m12*e1-h1)) - signit(1.0_ReKi,(m12*e2-h2)))/2) ! Security-Hess1962-page47-top
+         TAN12=Pi_loc*aint((signit(1.0_ReKi,(m12*e1-h1)) - signit(1.0_ReKi,(m12*e2-h2)))/2) ! Security-Hess1962-page47-top
       else
          TAN12= atan((m12*e1-h1)/(DPp(3)*r1)) - atan((m12*e2-h2)/(DPp(3)*r2))
       endif
@@ -570,7 +568,7 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    else
       m23=(eta3-eta2)/(xi3-xi2)
       if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur 
-         TAN23=pi*aint((signit(1.0_ReKi,(m23*e2-h2)) - signit(1.0_ReKi,(m23*e3-h3)))/2) ! Security-Hess1962-page47-top
+         TAN23=Pi_loc*aint((signit(1.0_ReKi,(m23*e2-h2)) - signit(1.0_ReKi,(m23*e3-h3)))/2) ! Security-Hess1962-page47-top
       else
          TAN23= atan((m23*e2-h2)/(DPp(3)*r2)) - atan((m23*e3-h3)/(DPp(3)*r3))
       endif
@@ -581,7 +579,7 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    else
       m34=(eta4-eta3)/(xi4-xi3)
       if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur 
-         TAN34=pi*aint((signit(1.0_ReKi,(m34*e3-h3)) - signit(1.0_ReKi,(m34*e4-h4)))/2) ! Security-Hess1962-page47-top
+         TAN34=Pi_loc*aint((signit(1.0_ReKi,(m34*e3-h3)) - signit(1.0_ReKi,(m34*e4-h4)))/2) ! Security-Hess1962-page47-top
       else
          TAN34= atan((m34*e3-h3)/(DPp(3)*r3)) - atan((m34*e4-h4)/(DPp(3)*r4))
       endif
@@ -592,17 +590,20 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    else
       m41=(eta1-eta4)/(xi1-xi4)
       if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur 
-         TAN41=pi*aint((signit(1.0_ReKi,(m41*e4-h4)) - signit(1.0_ReKi,(m41*e1-h1)))/2) ! Security-Hess1962-page47-top
+         TAN41=Pi_loc*aint((signit(1.0_ReKi,(m41*e4-h4)) - signit(1.0_ReKi,(m41*e1-h1)))/2) ! Security-Hess1962-page47-top
       else
          TAN41= atan((m41*e4-h4)/(DPp(3)*r4)) - atan((m41*e1-h1)/(DPp(3)*r1))
       endif
    endif
    ! --- Velocity  in Panel frame
-   Vp(1)= Sigma/(fourpi)*( (eta2-eta1)*RJ12 + (eta3-eta2)*RJ23 + (eta4-eta3)*RJ34 + (eta1-eta4)*RJ41 )
-   Vp(2)= Sigma/(fourpi)*( (xi1-xi2)  *RJ12 + (xi2-xi3)  *RJ23 +  (xi3-xi4) *RJ34 +  (xi4-xi1) *RJ41 )
-   Vp(3)= Sigma/(fourpi)*( ( TAN12 ) + ( TAN23 ) + ( TAN34 ) + ( TAN41 ) )
+   Vp(1)= Sigma*FourPiInv_loc*( (eta2-eta1)*RJ12 + (eta3-eta2)*RJ23 + (eta4-eta3)*RJ34 + (eta1-eta4)*RJ41 )
+   Vp(2)= Sigma*FourPiInv_loc*( (xi1-xi2)  *RJ12 + (xi2-xi3)  *RJ23 +  (xi3-xi4) *RJ34 +  (xi4-xi1) *RJ41 )
+   Vp(3)= Sigma*FourPiInv_loc*( ( TAN12 ) + ( TAN23 ) + ( TAN34 ) + ( TAN41 ) )
    ! --- Velocity in Reference frame 
-   UI(1:3) = matmul(transpose(R_g2p), Vp(1:3))
+   ! Unrolled matmul(transpose(R_g2p), Vp(1:3))
+   UI(1) = R_g2p(1,1)*Vp(1) + R_g2p(2,1)*Vp(2) + R_g2p(3,1)*Vp(3)
+   UI(2) = R_g2p(1,2)*Vp(1) + R_g2p(2,2)*Vp(2) + R_g2p(3,2)*Vp(3)
+   UI(3) = R_g2p(1,3)*Vp(1) + R_g2p(2,3)*Vp(2) + R_g2p(3,3)*Vp(3)
 end subroutine  ui_quad_src_11
 
 !> Induced velocity from one source panel at one control point (Target version)
@@ -615,7 +616,6 @@ subroutine ui_quad_src_11_target(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    real(ReKi), dimension(4),   intent(in)  :: eta        !< Panel points  coordinates
    real(ReKi), dimension(3,3), intent(in)  :: R_g2p !< 3 x 3, global 2 panel
    real(ReKi),parameter       :: eps_quadsource=1e-6_ReKi !!!!!!!!!!!!!!!!!! !< Used if z coordinate close to zero
-   real(ReKi), dimension(3,3) :: tA                         !<
    real(ReKi)                 :: d12, d23, d34, d41         !<
    real(ReKi)                 :: m12, m23, m34, m41         !<
    real(ReKi)                 :: xi1,  xi2,  xi3,  xi4      !<
@@ -628,7 +628,13 @@ subroutine ui_quad_src_11_target(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    real(ReKi), dimension(3)   :: Vp                         !<
    real(ReKi), dimension(3)   :: DP                         !<
    real(ReKi), dimension(3)   :: DPp                        !<
+   real(ReKi)                 :: Pi_loc, FourPiInv_loc      !< Local constants
    integer :: i, j
+
+   ! Define local constants to avoid global parameter issues in OpenMP offloading
+   Pi_loc = acos(-1.0_ReKi)
+   FourPiInv_loc = 1.0_ReKi / (4.0_ReKi * Pi_loc)
+
    xi1=xi(1)
    xi2=xi(2)
    xi3=xi(3)
@@ -698,7 +704,7 @@ subroutine ui_quad_src_11_target(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    else
       m12=(eta2-eta1)/(xi2-xi1)
       if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur
-         TAN12=pi*aint((signit(1.0_ReKi,(m12*e1-h1)) - signit(1.0_ReKi,(m12*e2-h2)))/2) ! Security-Hess1962-page47-top
+         TAN12=Pi_loc*aint((signit(1.0_ReKi,(m12*e1-h1)) - signit(1.0_ReKi,(m12*e2-h2)))/2) ! Security-Hess1962-page47-top
       else
          TAN12= atan((m12*e1-h1)/(DPp(3)*r1)) - atan((m12*e2-h2)/(DPp(3)*r2))
       endif
@@ -709,7 +715,7 @@ subroutine ui_quad_src_11_target(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    else
       m23=(eta3-eta2)/(xi3-xi2)
       if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur
-         TAN23=pi*aint((signit(1.0_ReKi,(m23*e2-h2)) - signit(1.0_ReKi,(m23*e3-h3)))/2) ! Security-Hess1962-page47-top
+         TAN23=Pi_loc*aint((signit(1.0_ReKi,(m23*e2-h2)) - signit(1.0_ReKi,(m23*e3-h3)))/2) ! Security-Hess1962-page47-top
       else
          TAN23= atan((m23*e2-h2)/(DPp(3)*r2)) - atan((m23*e3-h3)/(DPp(3)*r3))
       endif
@@ -720,7 +726,7 @@ subroutine ui_quad_src_11_target(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    else
       m34=(eta4-eta3)/(xi4-xi3)
       if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur
-         TAN34=pi*aint((signit(1.0_ReKi,(m34*e3-h3)) - signit(1.0_ReKi,(m34*e4-h4)))/2) ! Security-Hess1962-page47-top
+         TAN34=Pi_loc*aint((signit(1.0_ReKi,(m34*e3-h3)) - signit(1.0_ReKi,(m34*e4-h4)))/2) ! Security-Hess1962-page47-top
       else
          TAN34= atan((m34*e3-h3)/(DPp(3)*r3)) - atan((m34*e4-h4)/(DPp(3)*r4))
       endif
@@ -731,15 +737,15 @@ subroutine ui_quad_src_11_target(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    else
       m41=(eta1-eta4)/(xi1-xi4)
       if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur
-         TAN41=pi*aint((signit(1.0_ReKi,(m41*e4-h4)) - signit(1.0_ReKi,(m41*e1-h1)))/2) ! Security-Hess1962-page47-top
+         TAN41=Pi_loc*aint((signit(1.0_ReKi,(m41*e4-h4)) - signit(1.0_ReKi,(m41*e1-h1)))/2) ! Security-Hess1962-page47-top
       else
          TAN41= atan((m41*e4-h4)/(DPp(3)*r4)) - atan((m41*e1-h1)/(DPp(3)*r1))
       endif
    endif
    ! --- Velocity  in Panel frame
-   Vp(1)= Sigma/(fourpi)*( (eta2-eta1)*RJ12 + (eta3-eta2)*RJ23 + (eta4-eta3)*RJ34 + (eta1-eta4)*RJ41 )
-   Vp(2)= Sigma/(fourpi)*( (xi1-xi2)  *RJ12 + (xi2-xi3)  *RJ23 +  (xi3-xi4) *RJ34 +  (xi4-xi1) *RJ41 )
-   Vp(3)= Sigma/(fourpi)*( ( TAN12 ) + ( TAN23 ) + ( TAN34 ) + ( TAN41 ) )
+   Vp(1)= Sigma*FourPiInv_loc*( (eta2-eta1)*RJ12 + (eta3-eta2)*RJ23 + (eta4-eta3)*RJ34 + (eta1-eta4)*RJ41 )
+   Vp(2)= Sigma*FourPiInv_loc*( (xi1-xi2)  *RJ12 + (xi2-xi3)  *RJ23 +  (xi3-xi4) *RJ34 +  (xi4-xi1) *RJ41 )
+   Vp(3)= Sigma*FourPiInv_loc*( ( TAN12 ) + ( TAN23 ) + ( TAN34 ) + ( TAN41 ) )
    ! --- Velocity in Reference frame
    ! Unrolled matmul(transpose(R_g2p), Vp(1:3))
    ! Transpose of R_g2p means swapping indices: R_g2p(j, i)
@@ -783,7 +789,9 @@ end subroutine ui_quad_src_nn
 elemental real(ReKi) function signit(ref, val)
   real(ReKi),intent(in) ::ref
   real(ReKi),intent(in) ::val
-  if ( abs(val)>PRECISION_EPS ) then
+  real(ReKi) :: Eps
+  Eps = epsilon(val)
+  if ( abs(val)>Eps ) then
       signit = sign(ref, val)
   else
       signit = 1.0_ReKi

--- a/modules/aerodyn/src/FVW_BiotSavart.f90
+++ b/modules/aerodyn/src/FVW_BiotSavart.f90
@@ -472,8 +472,6 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    real(ReKi), dimension(4),   intent(in)  :: eta        !< Panel points  coordinates
    real(ReKi), dimension(3,3), intent(in)  :: R_g2p !< 3 x 3, global 2 panel
    real(ReKi),parameter       :: eps_quadsource=1e-6_ReKi !!!!!!!!!!!!!!!!!! !< Used if z coordinate close to zero
-   real(ReKi),parameter       :: Pi_loc = 3.1415926535897932384626433832795028841971_ReKi
-   real(ReKi),parameter       :: FourPiInv_loc = 0.25_ReKi / Pi_loc
    real(ReKi), dimension(3,3) :: tA                         !< 
    real(ReKi)                 :: d12, d23, d34, d41         !< 
    real(ReKi)                 :: m12, m23, m34, m41         !< 
@@ -503,10 +501,7 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
 
    ! transform control points in panel coordinate system using matrix 
    DP(1:3) = CP(1:3)-RefPoint(1:3)
-   ! Unrolled matmul(R_g2p, DP)
-   DPp(1) = R_g2p(1,1)*DP(1) + R_g2p(1,2)*DP(2) + R_g2p(1,3)*DP(3)
-   DPp(2) = R_g2p(2,1)*DP(1) + R_g2p(2,2)*DP(2) + R_g2p(2,3)*DP(3)
-   DPp(3) = R_g2p(3,1)*DP(1) + R_g2p(3,2)*DP(2) + R_g2p(3,3)*DP(3)
+   DPp     = matmul(R_g2p, DP)
 
    ! scalars
    r1 = sqrt((DPp(1)-xi1)**2 + (DPp(2)-eta1)**2 + DPp(3)**2)
@@ -557,7 +552,7 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    else
       m12=(eta2-eta1)/(xi2-xi1)
       if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur 
-         TAN12=Pi_loc*aint((signit(1.0_ReKi,(m12*e1-h1)) - signit(1.0_ReKi,(m12*e2-h2)))/2) ! Security-Hess1962-page47-top
+         TAN12=pi*aint((signit(1.0_ReKi,(m12*e1-h1)) - signit(1.0_ReKi,(m12*e2-h2)))/2) ! Security-Hess1962-page47-top
       else
          TAN12= atan((m12*e1-h1)/(DPp(3)*r1)) - atan((m12*e2-h2)/(DPp(3)*r2))
       endif
@@ -568,7 +563,7 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    else
       m23=(eta3-eta2)/(xi3-xi2)
       if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur 
-         TAN23=Pi_loc*aint((signit(1.0_ReKi,(m23*e2-h2)) - signit(1.0_ReKi,(m23*e3-h3)))/2) ! Security-Hess1962-page47-top
+         TAN23=pi*aint((signit(1.0_ReKi,(m23*e2-h2)) - signit(1.0_ReKi,(m23*e3-h3)))/2) ! Security-Hess1962-page47-top
       else
          TAN23= atan((m23*e2-h2)/(DPp(3)*r2)) - atan((m23*e3-h3)/(DPp(3)*r3))
       endif
@@ -579,7 +574,7 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    else
       m34=(eta4-eta3)/(xi4-xi3)
       if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur 
-         TAN34=Pi_loc*aint((signit(1.0_ReKi,(m34*e3-h3)) - signit(1.0_ReKi,(m34*e4-h4)))/2) ! Security-Hess1962-page47-top
+         TAN34=pi*aint((signit(1.0_ReKi,(m34*e3-h3)) - signit(1.0_ReKi,(m34*e4-h4)))/2) ! Security-Hess1962-page47-top
       else
          TAN34= atan((m34*e3-h3)/(DPp(3)*r3)) - atan((m34*e4-h4)/(DPp(3)*r4))
       endif
@@ -590,20 +585,17 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    else
       m41=(eta1-eta4)/(xi1-xi4)
       if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur 
-         TAN41=Pi_loc*aint((signit(1.0_ReKi,(m41*e4-h4)) - signit(1.0_ReKi,(m41*e1-h1)))/2) ! Security-Hess1962-page47-top
+         TAN41=pi*aint((signit(1.0_ReKi,(m41*e4-h4)) - signit(1.0_ReKi,(m41*e1-h1)))/2) ! Security-Hess1962-page47-top
       else
          TAN41= atan((m41*e4-h4)/(DPp(3)*r4)) - atan((m41*e1-h1)/(DPp(3)*r1))
       endif
    endif
    ! --- Velocity  in Panel frame
-   Vp(1)= Sigma*FourPiInv_loc*( (eta2-eta1)*RJ12 + (eta3-eta2)*RJ23 + (eta4-eta3)*RJ34 + (eta1-eta4)*RJ41 )
-   Vp(2)= Sigma*FourPiInv_loc*( (xi1-xi2)  *RJ12 + (xi2-xi3)  *RJ23 +  (xi3-xi4) *RJ34 +  (xi4-xi1) *RJ41 )
-   Vp(3)= Sigma*FourPiInv_loc*( ( TAN12 ) + ( TAN23 ) + ( TAN34 ) + ( TAN41 ) )
+   Vp(1)= Sigma/(fourpi)*( (eta2-eta1)*RJ12 + (eta3-eta2)*RJ23 + (eta4-eta3)*RJ34 + (eta1-eta4)*RJ41 )
+   Vp(2)= Sigma/(fourpi)*( (xi1-xi2)  *RJ12 + (xi2-xi3)  *RJ23 +  (xi3-xi4) *RJ34 +  (xi4-xi1) *RJ41 )
+   Vp(3)= Sigma/(fourpi)*( ( TAN12 ) + ( TAN23 ) + ( TAN34 ) + ( TAN41 ) )
    ! --- Velocity in Reference frame 
-   ! Unrolled matmul(transpose(R_g2p), Vp(1:3))
-   UI(1) = R_g2p(1,1)*Vp(1) + R_g2p(2,1)*Vp(2) + R_g2p(3,1)*Vp(3)
-   UI(2) = R_g2p(1,2)*Vp(1) + R_g2p(2,2)*Vp(2) + R_g2p(3,2)*Vp(3)
-   UI(3) = R_g2p(1,3)*Vp(1) + R_g2p(2,3)*Vp(2) + R_g2p(3,3)*Vp(3)
+   UI = matmul(transpose(R_g2p), Vp)
 end subroutine  ui_quad_src_11
 
 !> Induced velocity from one source panel at one control point (Target version)
@@ -628,12 +620,12 @@ subroutine ui_quad_src_11_target(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    real(ReKi), dimension(3)   :: Vp                         !<
    real(ReKi), dimension(3)   :: DP                         !<
    real(ReKi), dimension(3)   :: DPp                        !<
-   real(ReKi)                 :: Pi_loc, FourPiInv_loc      !< Local constants
+   real(ReKi)                 :: Pi_loc, FourPi_loc         !< Local constants
    integer :: i, j
 
    ! Define local constants to avoid global parameter issues in OpenMP offloading
    Pi_loc = acos(-1.0_ReKi)
-   FourPiInv_loc = 1.0_ReKi / (4.0_ReKi * Pi_loc)
+   FourPi_loc = 4.0_ReKi * Pi_loc
 
    xi1=xi(1)
    xi2=xi(2)
@@ -743,9 +735,9 @@ subroutine ui_quad_src_11_target(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
       endif
    endif
    ! --- Velocity  in Panel frame
-   Vp(1)= Sigma*FourPiInv_loc*( (eta2-eta1)*RJ12 + (eta3-eta2)*RJ23 + (eta4-eta3)*RJ34 + (eta1-eta4)*RJ41 )
-   Vp(2)= Sigma*FourPiInv_loc*( (xi1-xi2)  *RJ12 + (xi2-xi3)  *RJ23 +  (xi3-xi4) *RJ34 +  (xi4-xi1) *RJ41 )
-   Vp(3)= Sigma*FourPiInv_loc*( ( TAN12 ) + ( TAN23 ) + ( TAN34 ) + ( TAN41 ) )
+   Vp(1)= Sigma/FourPi_loc*( (eta2-eta1)*RJ12 + (eta3-eta2)*RJ23 + (eta4-eta3)*RJ34 + (eta1-eta4)*RJ41 )
+   Vp(2)= Sigma/FourPi_loc*( (xi1-xi2)  *RJ12 + (xi2-xi3)  *RJ23 +  (xi3-xi4) *RJ34 +  (xi4-xi1) *RJ41 )
+   Vp(3)= Sigma/FourPi_loc*( ( TAN12 ) + ( TAN23 ) + ( TAN34 ) + ( TAN41 ) )
    ! --- Velocity in Reference frame
    ! Unrolled matmul(transpose(R_g2p), Vp(1:3))
    ! Transpose of R_g2p means swapping indices: R_g2p(j, i)

--- a/modules/aerodyn/src/FVW_BiotSavart.f90
+++ b/modules/aerodyn/src/FVW_BiotSavart.f90
@@ -27,7 +27,35 @@ module FVW_BiotSavart
    real(ReKi),parameter    :: fourpi_inv =  0.25_ReKi / ACOS(-1.0_Reki )
    real(ReKi),parameter    :: fourpi     =  4.00_ReKi * ACOS(-1.0_Reki )
 
+   !$OMP DECLARE TARGET(signit)
+   !$OMP DECLARE TARGET(EqualRealNos_Target)
+   !$OMP DECLARE TARGET(ui_quad_src_11_target)
+
 contains
+
+   pure function EqualRealNos_Target(ReNum1, ReNum2)
+      real(ReKi), intent(in) :: ReNum1, ReNum2
+      logical :: EqualRealNos_Target
+      real(ReKi) :: Eps, Tol, Fraction
+      ! Hardcoded values for 8-byte and 4-byte real kinds to avoid epsilon intrinsic in target regions
+      real(ReKi), parameter :: Eps8 = 2.220446049250313e-16_ReKi
+      real(ReKi), parameter :: Eps4 = 1.1920929e-07_ReKi
+
+      ! Runtime check for precision
+      if (digits(ReNum1) > 24) then
+         Eps = Eps8
+      else
+         Eps = Eps4
+      endif
+
+      Tol = 100.0_ReKi * Eps / 2.0_ReKi
+      Fraction = max(abs(ReNum1+ReNum2), 1.0_ReKi)
+      if (abs(ReNum1 - ReNum2) <= Fraction*Tol) then
+         EqualRealNos_Target = .true.
+      else
+         EqualRealNos_Target = .false.
+      endif
+   end function EqualRealNos_Target
 
 
 !> Induced velocity from one segment at one control points
@@ -577,6 +605,149 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    UI(1:3) = matmul(transpose(R_g2p), Vp(1:3))
 end subroutine  ui_quad_src_11
 
+!> Induced velocity from one source panel at one control point (Target version)
+subroutine ui_quad_src_11_target(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
+   real(ReKi),                 intent(in)  :: Sigma      !< Source panel intensity
+   real(ReKi), dimension(3),   intent(in)  :: CP         !< Control Point
+   real(ReKi), dimension(3),   intent(out) :: UI         !< Induced velocity
+   real(ReKi), dimension(3),   intent(in)  :: RefPoint   !< Coordinate of panel origin in ref coordinates
+   real(ReKi), dimension(4),   intent(in)  :: xi         !< Panel points coordinates
+   real(ReKi), dimension(4),   intent(in)  :: eta        !< Panel points  coordinates
+   real(ReKi), dimension(3,3), intent(in)  :: R_g2p !< 3 x 3, global 2 panel
+   real(ReKi),parameter       :: eps_quadsource=1e-6_ReKi !!!!!!!!!!!!!!!!!! !< Used if z coordinate close to zero
+   real(ReKi), dimension(3,3) :: tA                         !<
+   real(ReKi)                 :: d12, d23, d34, d41         !<
+   real(ReKi)                 :: m12, m23, m34, m41         !<
+   real(ReKi)                 :: xi1,  xi2,  xi3,  xi4      !<
+   real(ReKi)                 :: eta1,  eta2,  eta3,  eta4  !<
+   real(ReKi)                 :: e1,  e2,  e3,  e4          !<
+   real(ReKi)                 :: h1,  h2,  h3,  h4          !<
+   real(ReKi)                 :: r1,  r2,  r3,  r4          !<
+   real(ReKi)                 :: RJ12, RJ23, RJ34, RJ41     !<
+   real(ReKi)                 :: TAN12, TAN23, TAN34, TAN41 !<
+   real(ReKi), dimension(3)   :: Vp                         !<
+   real(ReKi), dimension(3)   :: DP                         !<
+   real(ReKi), dimension(3)   :: DPp                        !<
+   integer :: i, j
+   xi1=xi(1)
+   xi2=xi(2)
+   xi3=xi(3)
+   xi4=xi(4)
+   eta1=eta(1)
+   eta2=eta(2)
+   eta3=eta(3)
+   eta4=eta(4)
+   !param that are constant for each panel, distances and slopes - The slopes can be if divided by zero NaN => security required
+   d12 = sqrt((xi2-xi1)**2+(eta2-eta1)**2)
+   d23 = sqrt((xi3-xi2)**2+(eta3-eta2)**2)
+   d34 = sqrt((xi4-xi3)**2+(eta4-eta3)**2)
+   d41 = sqrt((xi1-xi4)**2+(eta1-eta4)**2)
+
+   ! transform control points in panel coordinate system using matrix
+   DP(1:3) = CP(1:3)-RefPoint(1:3)
+   ! Unrolled matmul(R_g2p, DP)
+   DPp(1) = R_g2p(1,1)*DP(1) + R_g2p(1,2)*DP(2) + R_g2p(1,3)*DP(3)
+   DPp(2) = R_g2p(2,1)*DP(1) + R_g2p(2,2)*DP(2) + R_g2p(2,3)*DP(3)
+   DPp(3) = R_g2p(3,1)*DP(1) + R_g2p(3,2)*DP(2) + R_g2p(3,3)*DP(3)
+
+   ! scalars
+   r1 = sqrt((DPp(1)-xi1)**2 + (DPp(2)-eta1)**2 + DPp(3)**2)
+   r2 = sqrt((DPp(1)-xi2)**2 + (DPp(2)-eta2)**2 + DPp(3)**2)
+   r3 = sqrt((DPp(1)-xi3)**2 + (DPp(2)-eta3)**2 + DPp(3)**2)
+   r4 = sqrt((DPp(1)-xi4)**2 + (DPp(2)-eta4)**2 + DPp(3)**2)
+   !
+   e1 = DPp(3)**2 + (DPp(1)-xi1)**2
+   e2 = DPp(3)**2 + (DPp(1)-xi2)**2
+   e3 = DPp(3)**2 + (DPp(1)-xi3)**2
+   e4 = DPp(3)**2 + (DPp(1)-xi4)**2
+   !
+   h1 = (DPp(2)-eta1)*(DPp(1)-xi1)
+   h2 = (DPp(2)-eta2)*(DPp(1)-xi2)
+   h3 = (DPp(2)-eta3)*(DPp(1)-xi3)
+   h4 = (DPp(2)-eta4)*(DPp(1)-xi4)
+   ! Velocities in element frame
+   ! --- Log term
+   ! Security - Katz Plotkin page 608 appendix D Code 11
+   if ( r1+r2-d12<=0.0_ReKi .or. d12 <=0.0_ReKi ) then
+      RJ12=0._ReKi
+   else
+      RJ12=1/d12 * log((r1+r2-d12)/(r1+r2+d12))
+   endif
+
+   if ( r2+r3-d23<=0.0_ReKi .or. d23 <=0.0_ReKi ) then
+      RJ23=0._ReKi
+   else
+      RJ23=1/d23 * log((r2+r3-d23)/(r2+r3+d23))
+   endif
+
+   if ( r3+r4-d34<=0.0_ReKi .or. d34 <=0.0_ReKi ) then
+      RJ34=0._ReKi
+   else
+      RJ34=1/d34 * log((r3+r4-d34)/(r3+r4+d34))
+   endif
+
+   if ( r4+r1-d41<=0.0_ReKi .or. d41 <=0.0_ReKi ) then
+      RJ41=0._ReKi
+   else
+      RJ41=1/d41 * log((r4+r1-d41)/(r4+r1+d41))
+   endif
+   ! --- Tan term
+   ! 12
+   if (EqualRealNos_Target(xi2,xi1)) then ! Security - Hess 1962 - page 47 - bottom
+      TAN12=0._ReKi
+   else
+      m12=(eta2-eta1)/(xi2-xi1)
+      if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur
+         TAN12=pi*aint((signit(1.0_ReKi,(m12*e1-h1)) - signit(1.0_ReKi,(m12*e2-h2)))/2) ! Security-Hess1962-page47-top
+      else
+         TAN12= atan((m12*e1-h1)/(DPp(3)*r1)) - atan((m12*e2-h2)/(DPp(3)*r2))
+      endif
+   endif
+   ! 23
+   if (EqualRealNos_Target(xi3,xi2)) then ! Security - Hess 1962 - page 47 - bottom
+      TAN23=0._ReKi
+   else
+      m23=(eta3-eta2)/(xi3-xi2)
+      if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur
+         TAN23=pi*aint((signit(1.0_ReKi,(m23*e2-h2)) - signit(1.0_ReKi,(m23*e3-h3)))/2) ! Security-Hess1962-page47-top
+      else
+         TAN23= atan((m23*e2-h2)/(DPp(3)*r2)) - atan((m23*e3-h3)/(DPp(3)*r3))
+      endif
+   endif
+   ! 34
+   if (EqualRealNos_Target(xi4,xi3)) then ! Security - Hess 1962 - page 47 - bottom
+      TAN34=0._ReKi
+   else
+      m34=(eta4-eta3)/(xi4-xi3)
+      if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur
+         TAN34=pi*aint((signit(1.0_ReKi,(m34*e3-h3)) - signit(1.0_ReKi,(m34*e4-h4)))/2) ! Security-Hess1962-page47-top
+      else
+         TAN34= atan((m34*e3-h3)/(DPp(3)*r3)) - atan((m34*e4-h4)/(DPp(3)*r4))
+      endif
+   endif
+   ! 41
+   if (EqualRealNos_Target(xi1,xi4)) then ! Security - Hess 1962 - page 47 - bottom
+      TAN41=0._ReKi
+   else
+      m41=(eta1-eta4)/(xi1-xi4)
+      if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur
+         TAN41=pi*aint((signit(1.0_ReKi,(m41*e4-h4)) - signit(1.0_ReKi,(m41*e1-h1)))/2) ! Security-Hess1962-page47-top
+      else
+         TAN41= atan((m41*e4-h4)/(DPp(3)*r4)) - atan((m41*e1-h1)/(DPp(3)*r1))
+      endif
+   endif
+   ! --- Velocity  in Panel frame
+   Vp(1)= Sigma/(fourpi)*( (eta2-eta1)*RJ12 + (eta3-eta2)*RJ23 + (eta4-eta3)*RJ34 + (eta1-eta4)*RJ41 )
+   Vp(2)= Sigma/(fourpi)*( (xi1-xi2)  *RJ12 + (xi2-xi3)  *RJ23 +  (xi3-xi4) *RJ34 +  (xi4-xi1) *RJ41 )
+   Vp(3)= Sigma/(fourpi)*( ( TAN12 ) + ( TAN23 ) + ( TAN34 ) + ( TAN41 ) )
+   ! --- Velocity in Reference frame
+   ! Unrolled matmul(transpose(R_g2p), Vp(1:3))
+   ! Transpose of R_g2p means swapping indices: R_g2p(j, i)
+   UI(1) = R_g2p(1,1)*Vp(1) + R_g2p(2,1)*Vp(2) + R_g2p(3,1)*Vp(3)
+   UI(2) = R_g2p(1,2)*Vp(1) + R_g2p(2,2)*Vp(2) + R_g2p(3,2)*Vp(3)
+   UI(3) = R_g2p(1,3)*Vp(1) + R_g2p(2,3)*Vp(2) + R_g2p(3,3)*Vp(3)
+end subroutine  ui_quad_src_11_target
+
 !> Induced velocity by several flat quadrilateral source panels on multiple control points (CPs)
 subroutine ui_quad_src_nn(CPs, Sigmas, xi, eta, RefPoint, R_g2p, UI, nCPs, nPanels)
    integer,                            intent(in)    :: nCPs
@@ -591,18 +762,22 @@ subroutine ui_quad_src_nn(CPs, Sigmas, xi, eta, RefPoint, R_g2p, UI, nCPs, nPane
    real(ReKi) :: Uind_tmp(3) !< 
    real(ReKi) :: Uind_cum(3) !< 
    integer    :: ip, icp     !< loop index
-   !$OMP PARALLEL DEFAULT(SHARED)
-   !$OMP DO PRIVATE(icp, Uind_cum, Uind_tmp, ip) schedule(runtime)
-   do icp=1,nCPs ! loop on Control Points
-      Uind_cum = 0.0_ReKi
-      do ip=1,nPanels !loop on panels 
-         call ui_quad_src_11(CPs(:,icp), Sigmas(ip), xi(:,ip), eta(:,ip), RefPoint(:,ip), R_g2p(:,:,ip), Uind_tmp)
-         Uind_cum = Uind_cum + Uind_tmp
-      enddo
-      UI(1:3,icp) = UI(1:3,icp) + Uind_cum
-   end do ! control points
-   !$OMP END DO 
-   !$OMP END PARALLEL
+   if (nCPs > 0 .and. nPanels > 0) then
+      !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO DEFAULT(SHARED) &
+      !$OMP MAP(to: CPs(1:3,1:nCPs), Sigmas(1:nPanels), RefPoint(1:3,1:nPanels), &
+      !$OMP         xi(1:4,1:nPanels), eta(1:4,1:nPanels), R_g2p(1:3,1:3,1:nPanels)) &
+      !$OMP MAP(tofrom: UI(1:3,1:nCPs)) &
+      !$OMP PRIVATE(icp, Uind_cum, Uind_tmp, ip)
+      do icp=1,nCPs ! loop on Control Points
+         Uind_cum = 0.0_ReKi
+         do ip=1,nPanels !loop on panels
+            call ui_quad_src_11_target(CPs(:,icp), Sigmas(ip), xi(:,ip), eta(:,ip), RefPoint(:,ip), R_g2p(:,:,ip), Uind_tmp)
+            Uind_cum = Uind_cum + Uind_tmp
+         enddo
+         UI(1:3,icp) = UI(1:3,icp) + Uind_cum
+      end do ! control points
+      !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
+   endif
 end subroutine ui_quad_src_nn
 
 elemental real(ReKi) function signit(ref, val)


### PR DESCRIPTION
⚡ Bolt: GPU offloading for ui_quad_src_nn

💡 What:
- Implemented OpenMP offloading for `ui_quad_src_nn` using `!$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO`.
- Created `ui_quad_src_11_target` subroutine:
    - Clone of `ui_quad_src_11` but marked with `!$OMP DECLARE TARGET`.
    - Replaced `matmul` and `transpose` intrinsics with explicit unrolled loops for 3x3 matrices to improve performance and compatibility on GPUs.
    - Uses local `EqualRealNos_Target` instead of `NWTC_Library`'s version.
- Added `EqualRealNos_Target` helper:
    - Determines epsilon at runtime (or via compiler folding) to avoid `epsilon` intrinsic parameter initialization issues in device code.
- Marked `signit`, `EqualRealNos_Target`, and `ui_quad_src_11_target` with `!$OMP DECLARE TARGET`.

🎯 Why:
- To enable GPU acceleration for the N-body induced velocity calculation in the Free Vortex Wake (FVW) module, which is a computationally intensive part of the simulation.
- `ui_quad_src_nn` involves a doubly nested loop (Control Points x Panels) that is highly parallelizable.

📊 Impact:
- Expected significant speedup for FVW simulations on GPU-enabled systems.
- Ensures robust execution on `gfortran` OpenMP offloading by avoiding known pitfalls with intrinsics and array descriptors.

🔬 Measurement:
- Verify correctness by running regression tests (e.g., `MHK_RM1_Floating_MR_Linear` or `ModAmb_3` if applicable).
- Performance can be measured by comparing wall-clock time of `ui_quad_src_nn` on CPU vs GPU.

---
*PR created automatically by Jules for task [8876045754330152245](https://jules.google.com/task/8876045754330152245) started by @mayankchetan*