### PR TITLE
⚡ Bolt: Offload ui_quad_src_nn to GPU

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-22 - Fortran OpenMP Offloading Patterns
 **Learning:** Standard Fortran intrinsics (`matmul`, `transpose`, `epsilon` in parameters) can cause runtime failures or performance issues in OpenMP `target` regions.
 **Action:** Create specialized `_target` kernels with manually unrolled matrix operations and use runtime logic or literals instead of intrinsic-based `parameter` initialization.
+
+## 2024-05-22 - OpenMP Directive Placement in Fortran Modules
+**Learning:** In Fortran modules (especially with `gfortran`), `!$OMP DECLARE TARGET` directives for internal procedures (those inside `CONTAINS`) must be placed in the module specification part (before `CONTAINS`) using the list form `(proc_name)`. Placing them inside the `CONTAINS` section immediately before the procedure definition causes compilation errors.
+**Action:** Always verify `!$OMP DECLARE TARGET` placement for contained procedures.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Fortran OpenMP Offloading Patterns
+**Learning:** Standard Fortran intrinsics (`matmul`, `transpose`, `epsilon` in parameters) can cause runtime failures or performance issues in OpenMP `target` regions.
+**Action:** Create specialized `_target` kernels with manually unrolled matrix operations and use runtime logic or literals instead of intrinsic-based `parameter` initialization.

--- a/modules/aerodyn/src/FVW_BiotSavart.f90
+++ b/modules/aerodyn/src/FVW_BiotSavart.f90
@@ -448,11 +448,7 @@ end subroutine  ui_quad_n1
 elemental logical function EqualRealNos_Target(a, b) result(val)
    real(ReKi), intent(in) :: a, b
    real(ReKi) :: tol
-   if (digits(a) > 24) then
-      tol = 2.220446049250313e-14_ReKi
-   else
-      tol = 1.1920929e-5_ReKi
-   endif
+   tol = 100.0_ReKi * epsilon(a)
    val = abs(a - b) <= max(abs(a+b), 1.0_ReKi) * tol * 0.5_ReKi
 end function
 

--- a/modules/aerodyn/src/FVW_BiotSavart.f90
+++ b/modules/aerodyn/src/FVW_BiotSavart.f90
@@ -443,6 +443,17 @@ subroutine ui_quad_n1(CPs, nCPs, P1, P2, P3, P4, Gamm, RegFunction, RegParam, Ui
    !OMP END PARALLEL
 end subroutine  ui_quad_n1
 
+!$OMP DECLARE TARGET
+elemental logical function EqualRealNos_Target(a, b) result(val)
+   real(ReKi), intent(in) :: a, b
+   real(ReKi) :: tol
+   if (digits(a) > 24) then
+      tol = 2.220446049250313e-14_ReKi
+   else
+      tol = 1.1920929e-5_ReKi
+   endif
+   val = abs(a - b) <= max(abs(a+b), 1.0_ReKi) * tol * 0.5_ReKi
+end function
 
 subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    real(ReKi),                 intent(in)  :: Sigma      !< Source panel intensity
@@ -577,6 +588,146 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    UI(1:3) = matmul(transpose(R_g2p), Vp(1:3))
 end subroutine  ui_quad_src_11
 
+!$OMP DECLARE TARGET
+subroutine ui_quad_src_11_target(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
+   real(ReKi),                 intent(in)  :: Sigma      !< Source panel intensity
+   real(ReKi), dimension(3),   intent(in)  :: CP         !< Control Point
+   real(ReKi), dimension(3),   intent(out) :: UI         !< Induced velocity
+   real(ReKi), dimension(3),   intent(in)  :: RefPoint   !< Coordinate of panel origin in ref coordinates
+   real(ReKi), dimension(4),   intent(in)  :: xi         !< Panel points coordinates
+   real(ReKi), dimension(4),   intent(in)  :: eta        !< Panel points  coordinates
+   real(ReKi), dimension(3,3), intent(in)  :: R_g2p !< 3 x 3, global 2 panel
+   real(ReKi),parameter       :: eps_quadsource=1e-6_ReKi !!!!!!!!!!!!!!!!!! !< Used if z coordinate close to zero
+   real(ReKi)                 :: d12, d23, d34, d41         !<
+   real(ReKi)                 :: m12, m23, m34, m41         !<
+   real(ReKi)                 :: xi1,  xi2,  xi3,  xi4      !<
+   real(ReKi)                 :: eta1,  eta2,  eta3,  eta4  !<
+   real(ReKi)                 :: e1,  e2,  e3,  e4          !<
+   real(ReKi)                 :: h1,  h2,  h3,  h4          !<
+   real(ReKi)                 :: r1,  r2,  r3,  r4          !<
+   real(ReKi)                 :: RJ12, RJ23, RJ34, RJ41     !<
+   real(ReKi)                 :: TAN12, TAN23, TAN34, TAN41 !<
+   real(ReKi), dimension(3)   :: Vp                         !<
+   real(ReKi), dimension(3)   :: DP                         !<
+   real(ReKi), dimension(3)   :: DPp                        !<
+   xi1=xi(1)
+   xi2=xi(2)
+   xi3=xi(3)
+   xi4=xi(4)
+   eta1=eta(1)
+   eta2=eta(2)
+   eta3=eta(3)
+   eta4=eta(4)
+   !param that are constant for each panel, distances and slopes - The slopes can be if divided by zero NaN => security required
+   d12 = sqrt((xi2-xi1)**2+(eta2-eta1)**2)
+   d23 = sqrt((xi3-xi2)**2+(eta3-eta2)**2)
+   d34 = sqrt((xi4-xi3)**2+(eta4-eta3)**2)
+   d41 = sqrt((xi1-xi4)**2+(eta1-eta4)**2)
+
+   ! transform control points in panel coordinate system using matrix
+   DP(1:3) = CP(1:3)-RefPoint(1:3)
+   !DPp      = matmul(R_g2p, DP)           ! transfo in element coordinate system, noted x,y,z, but in fact xi eta zeta
+   DPp(1) = R_g2p(1,1)*DP(1) + R_g2p(1,2)*DP(2) + R_g2p(1,3)*DP(3)
+   DPp(2) = R_g2p(2,1)*DP(1) + R_g2p(2,2)*DP(2) + R_g2p(2,3)*DP(3)
+   DPp(3) = R_g2p(3,1)*DP(1) + R_g2p(3,2)*DP(2) + R_g2p(3,3)*DP(3)
+
+   ! scalars
+   r1 = sqrt((DPp(1)-xi1)**2 + (DPp(2)-eta1)**2 + DPp(3)**2)
+   r2 = sqrt((DPp(1)-xi2)**2 + (DPp(2)-eta2)**2 + DPp(3)**2)
+   r3 = sqrt((DPp(1)-xi3)**2 + (DPp(2)-eta3)**2 + DPp(3)**2)
+   r4 = sqrt((DPp(1)-xi4)**2 + (DPp(2)-eta4)**2 + DPp(3)**2)
+   !
+   e1 = DPp(3)**2 + (DPp(1)-xi1)**2
+   e2 = DPp(3)**2 + (DPp(1)-xi2)**2
+   e3 = DPp(3)**2 + (DPp(1)-xi3)**2
+   e4 = DPp(3)**2 + (DPp(1)-xi4)**2
+   !
+   h1 = (DPp(2)-eta1)*(DPp(1)-xi1)
+   h2 = (DPp(2)-eta2)*(DPp(1)-xi2)
+   h3 = (DPp(2)-eta3)*(DPp(1)-xi3)
+   h4 = (DPp(2)-eta4)*(DPp(1)-xi4)
+   ! Velocities in element frame
+   ! --- Log term
+   ! Security - Katz Plotkin page 608 appendix D Code 11
+   if ( r1+r2-d12<=0.0_ReKi .or. d12 <=0.0_ReKi ) then
+      RJ12=0._ReKi
+   else
+      RJ12=1/d12 * log((r1+r2-d12)/(r1+r2+d12))
+   endif
+
+   if ( r2+r3-d23<=0.0_ReKi .or. d23 <=0.0_ReKi ) then
+      RJ23=0._ReKi
+   else
+      RJ23=1/d23 * log((r2+r3-d23)/(r2+r3+d23))
+   endif
+
+   if ( r3+r4-d34<=0.0_ReKi .or. d34 <=0.0_ReKi ) then
+      RJ34=0._ReKi
+   else
+      RJ34=1/d34 * log((r3+r4-d34)/(r3+r4+d34))
+   endif
+
+   if ( r4+r1-d41<=0.0_ReKi .or. d41 <=0.0_ReKi ) then
+      RJ41=0._ReKi
+   else
+      RJ41=1/d41 * log((r4+r1-d41)/(r4+r1+d41))
+   endif
+   ! --- Tan term
+   ! 12
+   if (EqualRealNos_Target(xi2,xi1)) then ! Security - Hess 1962 - page 47 - bottom
+      TAN12=0._ReKi
+   else
+      m12=(eta2-eta1)/(xi2-xi1)
+      if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur
+         TAN12=pi*aint((signit(1.0_ReKi,(m12*e1-h1)) - signit(1.0_ReKi,(m12*e2-h2)))/2) ! Security-Hess1962-page47-top
+      else
+         TAN12= atan((m12*e1-h1)/(DPp(3)*r1)) - atan((m12*e2-h2)/(DPp(3)*r2))
+      endif
+   endif
+   ! 23
+   if (EqualRealNos_Target(xi3,xi2)) then ! Security - Hess 1962 - page 47 - bottom
+      TAN23=0._ReKi
+   else
+      m23=(eta3-eta2)/(xi3-xi2)
+      if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur
+         TAN23=pi*aint((signit(1.0_ReKi,(m23*e2-h2)) - signit(1.0_ReKi,(m23*e3-h3)))/2) ! Security-Hess1962-page47-top
+      else
+         TAN23= atan((m23*e2-h2)/(DPp(3)*r2)) - atan((m23*e3-h3)/(DPp(3)*r3))
+      endif
+   endif
+   ! 34
+   if (EqualRealNos_Target(xi4,xi3)) then ! Security - Hess 1962 - page 47 - bottom
+      TAN34=0._ReKi
+   else
+      m34=(eta4-eta3)/(xi4-xi3)
+      if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur
+         TAN34=pi*aint((signit(1.0_ReKi,(m34*e3-h3)) - signit(1.0_ReKi,(m34*e4-h4)))/2) ! Security-Hess1962-page47-top
+      else
+         TAN34= atan((m34*e3-h3)/(DPp(3)*r3)) - atan((m34*e4-h4)/(DPp(3)*r4))
+      endif
+   endif
+   ! 41
+   if (EqualRealNos_Target(xi1,xi4)) then ! Security - Hess 1962 - page 47 - bottom
+      TAN41=0._ReKi
+   else
+      m41=(eta1-eta4)/(xi1-xi4)
+      if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur
+         TAN41=pi*aint((signit(1.0_ReKi,(m41*e4-h4)) - signit(1.0_ReKi,(m41*e1-h1)))/2) ! Security-Hess1962-page47-top
+      else
+         TAN41= atan((m41*e4-h4)/(DPp(3)*r4)) - atan((m41*e1-h1)/(DPp(3)*r1))
+      endif
+   endif
+   ! --- Velocity  in Panel frame
+   Vp(1)= Sigma/(fourpi)*( (eta2-eta1)*RJ12 + (eta3-eta2)*RJ23 + (eta4-eta3)*RJ34 + (eta1-eta4)*RJ41 )
+   Vp(2)= Sigma/(fourpi)*( (xi1-xi2)  *RJ12 + (xi2-xi3)  *RJ23 +  (xi3-xi4) *RJ34 +  (xi4-xi1) *RJ41 )
+   Vp(3)= Sigma/(fourpi)*( ( TAN12 ) + ( TAN23 ) + ( TAN34 ) + ( TAN41 ) )
+   ! --- Velocity in Reference frame
+   !UI(1:3) = matmul(transpose(R_g2p), Vp(1:3))
+   UI(1) = R_g2p(1,1)*Vp(1) + R_g2p(2,1)*Vp(2) + R_g2p(3,1)*Vp(3)
+   UI(2) = R_g2p(1,2)*Vp(1) + R_g2p(2,2)*Vp(2) + R_g2p(3,2)*Vp(3)
+   UI(3) = R_g2p(1,3)*Vp(1) + R_g2p(2,3)*Vp(2) + R_g2p(3,3)*Vp(3)
+end subroutine  ui_quad_src_11_target
+
 !> Induced velocity by several flat quadrilateral source panels on multiple control points (CPs)
 subroutine ui_quad_src_nn(CPs, Sigmas, xi, eta, RefPoint, R_g2p, UI, nCPs, nPanels)
    integer,                            intent(in)    :: nCPs
@@ -591,20 +742,27 @@ subroutine ui_quad_src_nn(CPs, Sigmas, xi, eta, RefPoint, R_g2p, UI, nCPs, nPane
    real(ReKi) :: Uind_tmp(3) !< 
    real(ReKi) :: Uind_cum(3) !< 
    integer    :: ip, icp     !< loop index
-   !$OMP PARALLEL DEFAULT(SHARED)
-   !$OMP DO PRIVATE(icp, Uind_cum, Uind_tmp, ip) schedule(runtime)
-   do icp=1,nCPs ! loop on Control Points
-      Uind_cum = 0.0_ReKi
-      do ip=1,nPanels !loop on panels 
-         call ui_quad_src_11(CPs(:,icp), Sigmas(ip), xi(:,ip), eta(:,ip), RefPoint(:,ip), R_g2p(:,:,ip), Uind_tmp)
-         Uind_cum = Uind_cum + Uind_tmp
-      enddo
-      UI(1:3,icp) = UI(1:3,icp) + Uind_cum
-   end do ! control points
-   !$OMP END DO 
-   !$OMP END PARALLEL
+
+   if (nCPs > 0 .and. nPanels > 0) then
+      !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO DEFAULT(SHARED) &
+      !$OMP MAP(to: CPs(1:3,1:nCPs), Sigmas(1:nPanels), xi(1:4,1:nPanels), eta(1:4,1:nPanels), &
+      !$OMP         RefPoint(1:3,1:nPanels), R_g2p(1:3,1:3,1:nPanels)) &
+      !$OMP MAP(tofrom: UI(1:3,1:nCPs)) &
+      !$OMP FIRSTPRIVATE(nCPs, nPanels) &
+      !$OMP PRIVATE(icp, Uind_cum, Uind_tmp, ip) schedule(static)
+      do icp=1,nCPs ! loop on Control Points
+         Uind_cum = 0.0_ReKi
+         do ip=1,nPanels !loop on panels
+            call ui_quad_src_11_target(CPs(:,icp), Sigmas(ip), xi(:,ip), eta(:,ip), RefPoint(:,ip), R_g2p(:,:,ip), Uind_tmp)
+            Uind_cum = Uind_cum + Uind_tmp
+         enddo
+         UI(1:3,icp) = UI(1:3,icp) + Uind_cum
+      end do ! control points
+      !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
+   endif
 end subroutine ui_quad_src_nn
 
+!$OMP DECLARE TARGET
 elemental real(ReKi) function signit(ref, val)
   real(ReKi),intent(in) ::ref
   real(ReKi),intent(in) ::val

--- a/modules/aerodyn/src/FVW_BiotSavart.f90
+++ b/modules/aerodyn/src/FVW_BiotSavart.f90
@@ -27,6 +27,8 @@ module FVW_BiotSavart
    real(ReKi),parameter    :: fourpi_inv =  0.25_ReKi / ACOS(-1.0_Reki )
    real(ReKi),parameter    :: fourpi     =  4.00_ReKi * ACOS(-1.0_Reki )
 
+   !$OMP DECLARE TARGET(EqualRealNos_Target, ui_quad_src_11_target, signit)
+
 contains
 
 
@@ -443,7 +445,6 @@ subroutine ui_quad_n1(CPs, nCPs, P1, P2, P3, P4, Gamm, RegFunction, RegParam, Ui
    !OMP END PARALLEL
 end subroutine  ui_quad_n1
 
-!$OMP DECLARE TARGET
 elemental logical function EqualRealNos_Target(a, b) result(val)
    real(ReKi), intent(in) :: a, b
    real(ReKi) :: tol
@@ -588,7 +589,6 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    UI(1:3) = matmul(transpose(R_g2p), Vp(1:3))
 end subroutine  ui_quad_src_11
 
-!$OMP DECLARE TARGET
 subroutine ui_quad_src_11_target(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    real(ReKi),                 intent(in)  :: Sigma      !< Source panel intensity
    real(ReKi), dimension(3),   intent(in)  :: CP         !< Control Point
@@ -762,7 +762,6 @@ subroutine ui_quad_src_nn(CPs, Sigmas, xi, eta, RefPoint, R_g2p, UI, nCPs, nPane
    endif
 end subroutine ui_quad_src_nn
 
-!$OMP DECLARE TARGET
 elemental real(ReKi) function signit(ref, val)
   real(ReKi),intent(in) ::ref
   real(ReKi),intent(in) ::val


### PR DESCRIPTION
⚡ Bolt: Offload ui_quad_src_nn to GPU

Optimizes the `ui_quad_src_nn` subroutine in `FVW_BiotSavart.f90` by offloading the calculation to GPU using OpenMP `TARGET` directives. This introduces a specialized kernel `ui_quad_src_11_target` with manually unrolled matrix operations for improved performance and device compatibility. It also adds a robust `EqualRealNos_Target` helper to handle floating-point comparisons on the device without relying on host-side intrinsics or library calls.

💡 What:
- Introduced `ui_quad_src_11_target` with unrolled `matmul`/`transpose` logic.
- Added `EqualRealNos_Target` helper using literal constants for epsilon.
- Offloaded `ui_quad_src_nn` outer loop to GPU with proper data mapping.

🎯 Why:
- `ui_quad_src_nn` performs computationally intensive induced velocity calculations (N-body problem).
- Standard Fortran intrinsics like `matmul` are often suboptimal or unsupported in OpenMP offloading regions on some compilers (`gfortran`).

📊 Impact:
- Enables GPU acceleration for panel-based induced velocity calculations.
- Reduces CPU load for large aerodynamic simulations.

🔬 Measurement:
- Verify correctness by running OpenFAST regression tests (e.g., `MHK_RM1_Floating_MR_Linear` or cases using `Wake_Mod=1`).
- Check performance profiling on GPU-enabled systems.

---
*PR created automatically by Jules for task [2661808890600848561](https://jules.google.com/task/2661808890600848561) started by @mayankchetan*