### PR TITLE
⚡ Bolt: Offload FVW induced velocity calculation to GPU

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-23 - Fortran OpenMP Offloading Patterns
+**Learning:** When offloading Fortran subroutines that use external module functions (like `EqualRealNos`), reimplement them locally with `!$OMP DECLARE TARGET` to avoid modifying shared libraries. Also, calculate `PARAMETER` constants (like `epsilon`) at runtime in device functions to avoid initialization issues on GPU.
+**Action:** Use local `_Target` helper functions and runtime constant calculation for robust OpenMP offloading.

--- a/modules/aerodyn/src/FVW_BiotSavart.f90
+++ b/modules/aerodyn/src/FVW_BiotSavart.f90
@@ -444,7 +444,23 @@ subroutine ui_quad_n1(CPs, nCPs, P1, P2, P3, P4, Gamm, RegFunction, RegParam, Ui
 end subroutine  ui_quad_n1
 
 
+   pure function EqualRealNos_Target(ReNum1, ReNum2)
+      !$OMP DECLARE TARGET
+      real(ReKi), intent(in) :: ReNum1, ReNum2
+      logical                :: EqualRealNos_Target
+      real(ReKi)             :: Eps, Tol, Fraction
+      Eps = epsilon(ReNum1)
+      Tol = 100.0_ReKi*Eps / 2.0_ReKi
+      Fraction = max(abs(ReNum1+ReNum2), 1.0_ReKi)
+      if (abs(ReNum1 - ReNum2) <= Fraction*Tol) then
+         EqualRealNos_Target = .true.
+      else
+         EqualRealNos_Target = .false.
+      endif
+   end function EqualRealNos_Target
+
 subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
+   !$OMP DECLARE TARGET
    real(ReKi),                 intent(in)  :: Sigma      !< Source panel intensity
    real(ReKi), dimension(3),   intent(in)  :: CP         !< Control Point
    real(ReKi), dimension(3),   intent(out) :: UI         !< Induced velocity
@@ -526,7 +542,7 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    endif
    ! --- Tan term 
    ! 12
-   if (EqualRealNos(xi2,xi1)) then ! Security - Hess 1962 - page 47 - bottom
+   if (EqualRealNos_Target(xi2,xi1)) then ! Security - Hess 1962 - page 47 - bottom
       TAN12=0._ReKi
    else
       m12=(eta2-eta1)/(xi2-xi1)
@@ -537,7 +553,7 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
       endif
    endif
    ! 23
-   if (EqualRealNos(xi3,xi2)) then ! Security - Hess 1962 - page 47 - bottom
+   if (EqualRealNos_Target(xi3,xi2)) then ! Security - Hess 1962 - page 47 - bottom
       TAN23=0._ReKi
    else
       m23=(eta3-eta2)/(xi3-xi2)
@@ -548,7 +564,7 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
       endif
    endif 
    ! 34
-   if (EqualRealNos(xi4,xi3)) then ! Security - Hess 1962 - page 47 - bottom
+   if (EqualRealNos_Target(xi4,xi3)) then ! Security - Hess 1962 - page 47 - bottom
       TAN34=0._ReKi
    else
       m34=(eta4-eta3)/(xi4-xi3)
@@ -559,7 +575,7 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
       endif
    endif
    ! 41
-   if (EqualRealNos(xi1,xi4)) then ! Security - Hess 1962 - page 47 - bottom
+   if (EqualRealNos_Target(xi1,xi4)) then ! Security - Hess 1962 - page 47 - bottom
       TAN41=0._ReKi
    else
       m41=(eta1-eta4)/(xi1-xi4)
@@ -591,21 +607,24 @@ subroutine ui_quad_src_nn(CPs, Sigmas, xi, eta, RefPoint, R_g2p, UI, nCPs, nPane
    real(ReKi) :: Uind_tmp(3) !< 
    real(ReKi) :: Uind_cum(3) !< 
    integer    :: ip, icp     !< loop index
-   !$OMP PARALLEL DEFAULT(SHARED)
-   !$OMP DO PRIVATE(icp, Uind_cum, Uind_tmp, ip) schedule(runtime)
-   do icp=1,nCPs ! loop on Control Points
-      Uind_cum = 0.0_ReKi
-      do ip=1,nPanels !loop on panels 
-         call ui_quad_src_11(CPs(:,icp), Sigmas(ip), xi(:,ip), eta(:,ip), RefPoint(:,ip), R_g2p(:,:,ip), Uind_tmp)
-         Uind_cum = Uind_cum + Uind_tmp
-      enddo
-      UI(1:3,icp) = UI(1:3,icp) + Uind_cum
-   end do ! control points
-   !$OMP END DO 
-   !$OMP END PARALLEL
+   if (nCPs > 0 .and. nPanels > 0) then
+      !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO PRIVATE(icp, Uind_cum, Uind_tmp, ip) &
+      !$OMP MAP(to: CPs(:,1:nCPs), Sigmas(1:nPanels), xi(:,1:nPanels), eta(:,1:nPanels), RefPoint(:,1:nPanels), R_g2p(:,:,1:nPanels)) &
+      !$OMP MAP(tofrom: UI(:,1:nCPs))
+      do icp=1,nCPs ! loop on Control Points
+         Uind_cum = 0.0_ReKi
+         do ip=1,nPanels !loop on panels
+            call ui_quad_src_11(CPs(:,icp), Sigmas(ip), xi(:,ip), eta(:,ip), RefPoint(:,ip), R_g2p(:,:,ip), Uind_tmp)
+            Uind_cum = Uind_cum + Uind_tmp
+         enddo
+         UI(1:3,icp) = UI(1:3,icp) + Uind_cum
+      end do ! control points
+      !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
+   endif
 end subroutine ui_quad_src_nn
 
 elemental real(ReKi) function signit(ref, val)
+  !$OMP DECLARE TARGET
   real(ReKi),intent(in) ::ref
   real(ReKi),intent(in) ::val
   if ( abs(val)>PRECISION_EPS ) then


### PR DESCRIPTION
💡 What: Offloaded `ui_quad_src_nn` to GPU using OpenMP `TARGET` directives.
🎯 Why: Accelerate N-body induced velocity calculation (O(N^2)) which is a performance bottleneck in aerodynamic simulations.
📊 Impact: Expected significant speedup on GPU-enabled systems for large number of panels/control points.
🔬 Measurement: Verify correctness with `aerodyn_utest`. Performance can be measured by comparing execution time of `FVW_Test_WakeInducedVelocities` with and without OpenMP offloading enabled.


---
*PR created automatically by Jules for task [224707142150603](https://jules.google.com/task/224707142150603) started by @mayankchetan*