### PR TITLE
⚡ Bolt: Introduce GPU offloading for ui_quad_src_nn

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Fortran OpenMP Target Parameter Initialization
+**Learning:** In OpenMP `DECLARE TARGET` functions, initializing `PARAMETER`s using intrinsics (e.g., `epsilon(1.0_ReKi)`) can cause runtime Exit Code 8 on GPUs.
+**Action:** Use local variables initialized at runtime or pass values as arguments for constants derived from intrinsics in target regions.

--- a/modules/aerodyn/src/FVW_BiotSavart.f90
+++ b/modules/aerodyn/src/FVW_BiotSavart.f90
@@ -27,6 +27,8 @@ module FVW_BiotSavart
    real(ReKi),parameter    :: fourpi_inv =  0.25_ReKi / ACOS(-1.0_Reki )
    real(ReKi),parameter    :: fourpi     =  4.00_ReKi * ACOS(-1.0_Reki )
 
+   !$OMP DECLARE TARGET(EqualRealNos_Target, signit_Target)
+
 contains
 
 
@@ -444,7 +446,8 @@ subroutine ui_quad_n1(CPs, nCPs, P1, P2, P3, P4, Gamm, RegFunction, RegParam, Ui
 end subroutine  ui_quad_n1
 
 
-subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
+subroutine ui_quad_src_11_Target(CP, Sigma, xi, eta, RefPoint, R_g2p, UI, Pi_in, fourpi_in)
+   !$OMP DECLARE TARGET
    real(ReKi),                 intent(in)  :: Sigma      !< Source panel intensity
    real(ReKi), dimension(3),   intent(in)  :: CP         !< Control Point
    real(ReKi), dimension(3),   intent(out) :: UI         !< Induced velocity
@@ -452,6 +455,8 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    real(ReKi), dimension(4),   intent(in)  :: xi         !< Panel points coordinates
    real(ReKi), dimension(4),   intent(in)  :: eta        !< Panel points  coordinates
    real(ReKi), dimension(3,3), intent(in)  :: R_g2p !< 3 x 3, global 2 panel
+   real(ReKi),                 intent(in)  :: Pi_in
+   real(ReKi),                 intent(in)  :: fourpi_in
    real(ReKi),parameter       :: eps_quadsource=1e-6_ReKi !!!!!!!!!!!!!!!!!! !< Used if z coordinate close to zero
    real(ReKi), dimension(3,3) :: tA                         !< 
    real(ReKi)                 :: d12, d23, d34, d41         !< 
@@ -526,55 +531,66 @@ subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
    endif
    ! --- Tan term 
    ! 12
-   if (EqualRealNos(xi2,xi1)) then ! Security - Hess 1962 - page 47 - bottom
+   if (EqualRealNos_Target(xi2,xi1)) then ! Security - Hess 1962 - page 47 - bottom
       TAN12=0._ReKi
    else
       m12=(eta2-eta1)/(xi2-xi1)
       if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur 
-         TAN12=pi*aint((signit(1.0_ReKi,(m12*e1-h1)) - signit(1.0_ReKi,(m12*e2-h2)))/2) ! Security-Hess1962-page47-top
+         TAN12=Pi_in*aint((signit_Target(1.0_ReKi,(m12*e1-h1)) - signit_Target(1.0_ReKi,(m12*e2-h2)))/2) ! Security-Hess1962-page47-top
       else
          TAN12= atan((m12*e1-h1)/(DPp(3)*r1)) - atan((m12*e2-h2)/(DPp(3)*r2))
       endif
    endif
    ! 23
-   if (EqualRealNos(xi3,xi2)) then ! Security - Hess 1962 - page 47 - bottom
+   if (EqualRealNos_Target(xi3,xi2)) then ! Security - Hess 1962 - page 47 - bottom
       TAN23=0._ReKi
    else
       m23=(eta3-eta2)/(xi3-xi2)
       if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur 
-         TAN23=pi*aint((signit(1.0_ReKi,(m23*e2-h2)) - signit(1.0_ReKi,(m23*e3-h3)))/2) ! Security-Hess1962-page47-top
+         TAN23=Pi_in*aint((signit_Target(1.0_ReKi,(m23*e2-h2)) - signit_Target(1.0_ReKi,(m23*e3-h3)))/2) ! Security-Hess1962-page47-top
       else
          TAN23= atan((m23*e2-h2)/(DPp(3)*r2)) - atan((m23*e3-h3)/(DPp(3)*r3))
       endif
    endif 
    ! 34
-   if (EqualRealNos(xi4,xi3)) then ! Security - Hess 1962 - page 47 - bottom
+   if (EqualRealNos_Target(xi4,xi3)) then ! Security - Hess 1962 - page 47 - bottom
       TAN34=0._ReKi
    else
       m34=(eta4-eta3)/(xi4-xi3)
       if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur 
-         TAN34=pi*aint((signit(1.0_ReKi,(m34*e3-h3)) - signit(1.0_ReKi,(m34*e4-h4)))/2) ! Security-Hess1962-page47-top
+         TAN34=Pi_in*aint((signit_Target(1.0_ReKi,(m34*e3-h3)) - signit_Target(1.0_ReKi,(m34*e4-h4)))/2) ! Security-Hess1962-page47-top
       else
          TAN34= atan((m34*e3-h3)/(DPp(3)*r3)) - atan((m34*e4-h4)/(DPp(3)*r4))
       endif
    endif
    ! 41
-   if (EqualRealNos(xi1,xi4)) then ! Security - Hess 1962 - page 47 - bottom
+   if (EqualRealNos_Target(xi1,xi4)) then ! Security - Hess 1962 - page 47 - bottom
       TAN41=0._ReKi
    else
       m41=(eta1-eta4)/(xi1-xi4)
       if( abs(DPp(3))<eps_quadsource ) then ! case where z is too small, jumps may occur 
-         TAN41=pi*aint((signit(1.0_ReKi,(m41*e4-h4)) - signit(1.0_ReKi,(m41*e1-h1)))/2) ! Security-Hess1962-page47-top
+         TAN41=Pi_in*aint((signit_Target(1.0_ReKi,(m41*e4-h4)) - signit_Target(1.0_ReKi,(m41*e1-h1)))/2) ! Security-Hess1962-page47-top
       else
          TAN41= atan((m41*e4-h4)/(DPp(3)*r4)) - atan((m41*e1-h1)/(DPp(3)*r1))
       endif
    endif
    ! --- Velocity  in Panel frame
-   Vp(1)= Sigma/(fourpi)*( (eta2-eta1)*RJ12 + (eta3-eta2)*RJ23 + (eta4-eta3)*RJ34 + (eta1-eta4)*RJ41 )
-   Vp(2)= Sigma/(fourpi)*( (xi1-xi2)  *RJ12 + (xi2-xi3)  *RJ23 +  (xi3-xi4) *RJ34 +  (xi4-xi1) *RJ41 )
-   Vp(3)= Sigma/(fourpi)*( ( TAN12 ) + ( TAN23 ) + ( TAN34 ) + ( TAN41 ) )
+   Vp(1)= Sigma/(fourpi_in)*( (eta2-eta1)*RJ12 + (eta3-eta2)*RJ23 + (eta4-eta3)*RJ34 + (eta1-eta4)*RJ41 )
+   Vp(2)= Sigma/(fourpi_in)*( (xi1-xi2)  *RJ12 + (xi2-xi3)  *RJ23 +  (xi3-xi4) *RJ34 +  (xi4-xi1) *RJ41 )
+   Vp(3)= Sigma/(fourpi_in)*( ( TAN12 ) + ( TAN23 ) + ( TAN34 ) + ( TAN41 ) )
    ! --- Velocity in Reference frame 
    UI(1:3) = matmul(transpose(R_g2p), Vp(1:3))
+end subroutine  ui_quad_src_11_Target
+
+subroutine ui_quad_src_11(CP, Sigma, xi, eta, RefPoint, R_g2p, UI)
+   real(ReKi),                 intent(in)  :: Sigma      !< Source panel intensity
+   real(ReKi), dimension(3),   intent(in)  :: CP         !< Control Point
+   real(ReKi), dimension(3),   intent(out) :: UI         !< Induced velocity
+   real(ReKi), dimension(3),   intent(in)  :: RefPoint   !< Coordinate of panel origin in ref coordinates
+   real(ReKi), dimension(4),   intent(in)  :: xi         !< Panel points coordinates
+   real(ReKi), dimension(4),   intent(in)  :: eta        !< Panel points  coordinates
+   real(ReKi), dimension(3,3), intent(in)  :: R_g2p !< 3 x 3, global 2 panel
+   call ui_quad_src_11_Target(CP, Sigma, xi, eta, RefPoint, R_g2p, UI, Pi, fourpi)
 end subroutine  ui_quad_src_11
 
 !> Induced velocity by several flat quadrilateral source panels on multiple control points (CPs)
@@ -591,18 +607,25 @@ subroutine ui_quad_src_nn(CPs, Sigmas, xi, eta, RefPoint, R_g2p, UI, nCPs, nPane
    real(ReKi) :: Uind_tmp(3) !< 
    real(ReKi) :: Uind_cum(3) !< 
    integer    :: ip, icp     !< loop index
-   !$OMP PARALLEL DEFAULT(SHARED)
-   !$OMP DO PRIVATE(icp, Uind_cum, Uind_tmp, ip) schedule(runtime)
+   real(ReKi) :: Pi_loc, fourpi_loc
+
+   Pi_loc = Pi
+   fourpi_loc = fourpi
+
+   !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO schedule(static) &
+   !$OMP map(to: CPs(1:3,1:nCPs), Sigmas(1:nPanels), xi(1:4,1:nPanels), eta(1:4,1:nPanels), RefPoint(1:3,1:nPanels), R_g2p(1:3,1:3,1:nPanels)) &
+   !$OMP map(tofrom: UI(1:3,1:nCPs)) &
+   !$OMP firstprivate(nCPs, nPanels, Pi_loc, fourpi_loc) &
+   !$OMP private(icp, ip, Uind_cum, Uind_tmp)
    do icp=1,nCPs ! loop on Control Points
       Uind_cum = 0.0_ReKi
       do ip=1,nPanels !loop on panels 
-         call ui_quad_src_11(CPs(:,icp), Sigmas(ip), xi(:,ip), eta(:,ip), RefPoint(:,ip), R_g2p(:,:,ip), Uind_tmp)
+         call ui_quad_src_11_Target(CPs(:,icp), Sigmas(ip), xi(:,ip), eta(:,ip), RefPoint(:,ip), R_g2p(:,:,ip), Uind_tmp, Pi_loc, fourpi_loc)
          Uind_cum = Uind_cum + Uind_tmp
       enddo
       UI(1:3,icp) = UI(1:3,icp) + Uind_cum
    end do ! control points
-   !$OMP END DO 
-   !$OMP END PARALLEL
+   !$OMP END TARGET TEAMS DISTRIBUTE PARALLEL DO
 end subroutine ui_quad_src_nn
 
 elemental real(ReKi) function signit(ref, val)
@@ -614,5 +637,31 @@ elemental real(ReKi) function signit(ref, val)
       signit = 1.0_ReKi
   endif
 endfunction
+
+elemental real(ReKi) function signit_Target(ref, val)
+  real(ReKi),intent(in) ::ref
+  real(ReKi),intent(in) ::val
+  real(ReKi)            :: eps
+  eps = epsilon(val)
+  if ( abs(val)>eps ) then
+      signit_Target = sign(ref, val)
+  else
+      signit_Target = 1.0_ReKi
+  endif
+end function signit_Target
+
+pure function EqualRealNos_Target(ReNum1, ReNum2)
+    real(ReKi), intent(in) :: ReNum1, ReNum2
+    logical :: EqualRealNos_Target
+    real(ReKi) :: Eps, Tol, Fraction
+    Eps = epsilon(ReNum1)
+    Tol = 100.0_ReKi * Eps / 2.0_ReKi
+    Fraction = MAX( ABS(ReNum1+ReNum2), 1.0_ReKi )
+    IF ( ABS(ReNum1 - ReNum2) <= Fraction*Tol ) THEN
+       EqualRealNos_Target = .TRUE.
+    ELSE
+       EqualRealNos_Target = .FALSE.
+    ENDIF
+end function EqualRealNos_Target
 
 end module FVW_BiotSavart


### PR DESCRIPTION
* 💡 What: Implemented OpenMP Target offloading for the `ui_quad_src_nn` subroutine in `FVW_BiotSavart.f90`. This involves offloading the calculation of induced velocity from quadrilateral source panels to the GPU.
* 🎯 Why: To accelerate the computationally intensive N-body problem of calculating induced velocities, leveraging GPU parallelism.
* 📊 Impact: Expected significant performance improvement on systems with GPUs for simulations involving many aerodynamic panels.
* 🔬 Measurement: Verify correctness by running regression tests (e.g., `MHK_RM1_Floating_MR_Linear`, `ModAmb_3`). Performance can be measured by comparing execution time with and without OpenMP offloading enabled.

---
*PR created automatically by Jules for task [15869866102270461826](https://jules.google.com/task/15869866102270461826) started by @mayankchetan*